### PR TITLE
"Fixing" the missing JPDA

### DIFF
--- a/include/bayes_tracking/multitracker.h
+++ b/include/bayes_tracking/multitracker.h
@@ -39,7 +39,7 @@ struct observation_t {
 };
 
 typedef std::vector<observation_t> sequence_t;
-typedef enum {NN, JPDA, NNJPDA} association_t;
+typedef enum {NN, /*JPDA,*/ NNJPDA} association_t;
 
 // to be defined by user
 template<class FilterType>


### PR DESCRIPTION
See #6

The option of using only JPDA as an association algorithm was a relic from past development and is not supported anymore.
This change just comments the JPDA in the enum, preventing people from trying to use it.
