### PR TITLE
Flexible id associations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,16 @@ if(catkin_FOUND)
     LIBRARIES ${PROJECT_NAME}
   )
   include_directories(
-    ${catkin_INCLUDE_DIRS}
+    include ${catkin_INCLUDE_DIRS}
   )
 else(catkin_FOUND)
     message(STATUS "NOT found catkin")
+    include_directories(
+        include
+    )
 endif(catkin_FOUND)
 
 ## Headers
-include_directories(
-    include
-)
 ## Source files
 add_library(${PROJECT_NAME} STATIC
     src/bayes_tracking/associationmatrix.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,10 @@
 include_directories(../include)
 
 add_executable(simple_2d_tracking simple_2d_tracking.cpp)
+add_executable(simple_2d_tracking_tags simple_2d_tracking_tags.cpp)
 
 
 find_package( OpenCV REQUIRED )
 
 target_link_libraries(simple_2d_tracking bayes_tracking ${OpenCV_LIBS})
+target_link_libraries(simple_2d_tracking_tags bayes_tracking ${OpenCV_LIBS})

--- a/examples/simple_2d_tracking_tags.cpp
+++ b/examples/simple_2d_tracking_tags.cpp
@@ -1,0 +1,302 @@
+/***************************************************************************
+ *   Copyright (C) 2011 by Nicola Bellotto                                 *
+ *   nbellotto@lincoln.ac.uk                                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "bayes_tracking/multitracker.h"
+#include "bayes_tracking/models.h"
+#include "bayes_tracking/ekfilter.h"
+#include "bayes_tracking/ukfilter.h"
+#include "bayes_tracking/pfilter.h"
+#include <sys/time.h>
+#include "bayes_tracking/trackwin.h"
+#include <cstdio>
+
+#define SLEEP_TIME 10000  // sleep time in [us]
+
+
+using namespace std;
+using namespace MTRK;
+using namespace Models;
+
+
+typedef UKFilter Filter;
+const int numOfTarget = 3;
+const association_t alg = NN_LABELED;
+const observ_model_t om_flag = CARTESIAN;
+const std::string label = "test";
+
+static double getTime()
+{
+  timeval t;
+  gettimeofday(&t,NULL);
+  return (double)t.tv_sec + (double)t.tv_usec/1000000.0;
+}
+
+
+// rule to detect lost track
+template<class FilterType>
+bool MTRK::isLost(const FilterType* filter, double varLimit) {
+  // track lost if var(x)+var(y) > varLimit
+  if (filter->X(0,0) + filter->X(2,2) > sqr(varLimit))
+    return true;
+  return false;
+}
+
+// rule to create new track
+template<class FilterType>
+bool MTRK::initialize(FilterType* &filter, sequence_t& obsvSeq, observ_model_t om_flag) {
+  assert(obsvSeq.size());
+
+  if (om_flag == CARTESIAN) {
+    double dt = obsvSeq.back().time - obsvSeq.front().time;
+    assert(dt); // dt must not be null
+    FM::Vec v((obsvSeq.back().vec - obsvSeq.front().vec) / dt);
+
+    FM::Vec x(4);
+    FM::SymMatrix X(4,4);
+
+    x[0] = obsvSeq.back().vec[0];
+    x[1] = v[0];
+    x[2] = obsvSeq.back().vec[1];
+    x[3] = v[1];
+    X.clear();
+    X(0,0) = sqr(0.5);
+    X(1,1) = sqr(1.5);
+    X(2,2) = sqr(0.5);
+    X(3,3) = sqr(1.5);
+
+    filter = new FilterType(4);
+    filter->init(x, X);
+  }
+
+  if (om_flag == POLAR) {
+    double dt = obsvSeq.back().time - obsvSeq.front().time;
+    assert(dt); // dt must not be null
+    double x2 = obsvSeq.back().vec[1]*cos(obsvSeq.back().vec[0]);
+    double y2 = obsvSeq.back().vec[1]*sin(obsvSeq.back().vec[0]);
+    double x1 = obsvSeq.front().vec[1]*cos(obsvSeq.front().vec[0]);
+    double y1 = obsvSeq.front().vec[1]*sin(obsvSeq.front().vec[0]);
+
+    FM::Vec x(4);
+    FM::SymMatrix X(4,4);
+
+    x[0] = x2;
+    x[1] = (x2-x1)/dt;
+    x[2] = y2;
+    x[3] = (y2-y1)/dt;
+    X.clear();
+    X(0,0) = sqr(0.5);
+    X(1,1) = sqr(1.5);
+    X(2,2) = sqr(0.5);
+    X(3,3) = sqr(1.5);
+
+    filter = new FilterType(4);
+    filter->init(x, X);
+  }
+  return true;
+}
+
+
+// command line option
+bool textDebug = false;
+bool winDebug = false;
+bool sendPredictions = false;
+
+
+int main(int argc, char *argv[]) {
+  cout.precision(20);
+
+  // parse arguments
+  for (int c = 1; c < argc; c++) {
+    if (strcmp(argv[c], "-g") == 0 ) {
+      textDebug = true;
+      continue;
+    }
+    if (strcmp(argv[c], "-w") == 0 ) {
+      winDebug = true;
+      continue;
+    }
+    cerr << "Unknown option " << argv[c] << endl;
+    cerr << "Valid options are '-g' (text debug) and '-w' (visual debug)" << endl;
+    exit(EXIT_FAILURE);
+  }
+
+  MultiTracker<Filter, 4> mtrk;    // state [x, v_x, y, v_y]
+  CVModel cvm(5.0, 5.0);           // CV model with sigma_x = sigma_y = 5.0
+  CartesianModel ctm(1.0, 1.0);    // Cartesian observation model
+  PolarModel plm(0.3, 1.0);        // Polar observation model
+  FM::Vec observation(2);          // observation [x, y]
+  vector<FM::Vec> obsvBuffer;      // observation buffer
+
+  double dt, time = getTime(), obsvTime = -1;
+
+  TrackWin* trkwin = 0;
+  if (winDebug) {
+    trkwin = new TrackWin(__FILE__, 1200, 1200, 40.);
+    trkwin->setOrigin(0., 0., 0.);
+    trkwin->create();
+  }
+  char label[256];
+
+#if 0
+  Filter filter(4);
+  static bool initialized = false;
+  for (;;) {
+    dt = getTime() - time;
+    time += dt;
+
+    if (!initialized) {
+      FM::Vec x(4);
+      x[0] = 2 * cos(time);
+      x[1] = 0;
+      x[2] = 2 * sin(time);
+      x[3] = 0;
+      FM::SymMatrix X(4,4);
+      X.clear();
+      X(0,0) = sqr(0.5);
+      X(1,1) = sqr(0.1);
+      X(2,2) = sqr(0.5);
+      X(3,3) = sqr(0.1);
+      filter.init(x, X);
+      initialized = true;
+      cout << "initialized" << endl;
+    }
+
+    // prediction
+    cvm.update(dt);
+    filter.predict(cvm);
+
+    // observation
+    if (time - obsvTime > 30e-3) {
+      obsvTime = time;
+      FM::Vec obsv(2);
+      obsv[0] = 2 * cos(time);
+      obsv[1] = 2 * sin(time);
+      trkwin->setObject("O", obsv[0], obsv[1], TrackWin::NO_ORIENTATION, TrackWin::GREY);
+      filter.observe(bgm, obsv);
+    }
+
+    trkwin->setObject("T", filter.x[0], filter.x[2], atan2(filter.x[3], filter.x[1])/*orientation*/,
+          TrackWin::RED, sqrt(filter.X(0,0)), sqrt(filter.X(2,2))/*std dev*/);
+    trkwin->update(5);
+
+    usleep(SLEEP_TIME);
+  }
+
+#else
+  for (;;) {
+    ///////////////// estimation begin /////////////////
+    //     #warning fix 'dt' if not debugging
+    dt = /*20e-3;*/getTime() - time;
+    time += dt;
+
+    // prediction
+    cvm.update(dt);
+    mtrk.predict<CVModel>(cvm);
+
+    // observation
+    obsvBuffer.clear();
+    if (time - obsvTime > 30e-3) {
+      obsvTime = time;
+      for (int i = 0; i < numOfTarget; i++) {
+        FM::Vec obsv(2);
+	double range = 3 * (i+1);
+	double angle = time / (i+1);
+        // counter-clockwise
+	if (om_flag == CARTESIAN) {
+	  obsv[0] = range * cos(angle);
+	  obsv[1] = range * sin(angle);
+	  obsvBuffer.push_back(obsv);
+	  // clockwise
+	  obsv[0] = range * cos(-angle);
+	  obsv[1] = range * sin(-angle);
+	  obsvBuffer.push_back(obsv);
+	}
+	if (om_flag == POLAR) {
+	  obsv[0] = angle;
+	  obsv[1] = range;
+	  obsvBuffer.push_back(obsv);
+	  // clockwise
+	  obsv[0] = -angle;
+	  obsv[1] = range;
+	  obsvBuffer.push_back(obsv);
+	}
+	// put some false positives
+        if (rand() > 0.95*RAND_MAX) {
+          obsv[0] *= 2.0 * rand() / RAND_MAX;
+          obsv[1] *= 3.0 * rand() / RAND_MAX;
+          obsvBuffer.push_back(obsv);
+        }
+      }
+
+      // add last observation/s to tracker
+      vector<FM::Vec>::iterator li, liEnd = obsvBuffer.end();
+      for (li = obsvBuffer.begin(); li != liEnd; li++) {
+        observation[0] = (*li)[0];
+        observation[1] = (*li)[1];
+        if (rand() > 0.4*RAND_MAX)
+          mtrk.addObservation(observation, obsvTime, "rare");
+        else 
+          mtrk.addObservation(observation, obsvTime, "normal");
+
+        if (winDebug) {
+          // show on trackwin
+          sprintf(label, "(%f,%f)", observation[0], observation[1]);
+	  if(om_flag == CARTESIAN)
+	    trkwin->setObject(label, observation[0], observation[1], TrackWin::NO_ORIENTATION, TrackWin::GREY);
+	  if(om_flag == POLAR)
+	    trkwin->setObject(label, observation[1]*cos(observation[0]), observation[1]*sin(observation[0]), TrackWin::NO_ORIENTATION, TrackWin::GREY);
+	}
+      }
+
+      // process observations (if available) and update tracks
+      if (om_flag == CARTESIAN) {
+	mtrk.process(ctm, alg, CARTESIAN);
+      }
+      if (om_flag == POLAR) {
+	plm.update(0, 0, 0);
+	mtrk.process(plm, alg, POLAR);
+      }
+      //       mtrk.print();
+    }
+    ///////////////// estimation end /////////////////
+
+    // show on trackwin
+    if (winDebug) {
+    int n = mtrk.size();
+      for (int i = 0; i < n; i++) {
+        sprintf(label, "trk_%s", mtrk[i].tag.c_str());
+        trkwin->setObject(label, mtrk[i].filter->x[0], mtrk[i].filter->x[2], atan2(mtrk[i].filter->x[3], mtrk[i].filter->x[1])/*orientation*/,
+          TrackWin::RED, sqrt(mtrk[i].filter->X(0,0)), sqrt(mtrk[i].filter->X(2,2))/*std dev*/);
+      }
+      trkwin->update(5);
+    }
+
+    int slp = SLEEP_TIME - (int)(1e6 * (getTime() - time));
+    usleep(slp > 0 ? slp : 0);
+  }
+#endif
+
+  if (winDebug) {
+    trkwin->destroy();
+    delete trkwin;
+  }
+
+return EXIT_SUCCESS;
+}

--- a/include/bayes_tracking/multitracker.h
+++ b/include/bayes_tracking/multitracker.h
@@ -393,7 +393,8 @@ void addFilter(FilterType* filter, observation_t& observation)
     typename std::map<int, int>::iterator ai, aiEnd = m_assignments.end();
     for (ai = m_assignments.begin(); ai != aiEnd; ai++) {
       m_filters[ai->second].filter->observe(om, m_observations[ai->first].vec);
-      m_filters[ai->second].tag = m_observations[ai->first].tag;
+      if (m_filters[ai->second].tag.length() == 0) // if filter stil anonymous, name it
+      	m_filters[ai->second].tag = m_observations[ai->first].tag;
     }
   }
 

--- a/include/bayes_tracking/multitracker.h
+++ b/include/bayes_tracking/multitracker.h
@@ -21,6 +21,7 @@
 #include "bayes_tracking/associationmatrix.h"
 #include "bayes_tracking/jpda.h"
 #include <float.h>
+#include <stdio.h>
 
 using namespace Bayesian_filter;
 
@@ -236,16 +237,22 @@ void addFilter(FilterType* filter, observation_t& observation)
         S = Zp + om.Z;  // H*P*H' + R
         for (int i = 0; i < M; i++) {
 
-         // Only Check NN_LABELED, NNJPDA_LABELED tag associate not yet implemented
-         if (alg == NN_LABELED || alg == NNJPDA_LABELED) 
-         {
-           // Assign maximum cost if observations and trajectories labelled do not match
-           if (m_observations[i].tag != m_filters[j].tag) 
-           {
-             amat[i][j] = DBL_MAX;
-             continue;
-           }
-         }
+		    // Only Check NN_LABELED, NNJPDA_LABELED tag associate not yet implemented
+		    if (alg == NN_LABELED || alg == NNJPDA_LABELED) 
+		    {
+		    	// if either tag is empty, continue associating as if it was unlabelled
+		    	if (
+			       	m_observations[i].tag.length() == 0 ||
+			       	m_filters[j].tag.length() == 0
+			       	)
+		    		continue;
+		        // Assign maximum cost if observations and trajectories labelled do not match
+		        if (m_observations[i].tag != m_filters[j].tag) 
+		        {
+		        	amat[i][j] = DBL_MAX;
+		        	continue;
+		       	}
+		    }
           s = zp - m_observations[i].vec;
           om.normalise(s, zp);
           try {
@@ -346,7 +353,7 @@ void addFilter(FilterType* filter, observation_t& observation)
           si->push_back(m_observations[*ui]);
           FilterType* filter;
           if (si->size() >= seqSize && initialize(filter, *si, om_flag)) {  // there's a minimum number of sequential observations
-            addFilter(filter);
+            addFilter(filter, m_observations[*ui]);
             // remove sequence
             si = m_sequences.erase(si);
             matched = true;
@@ -386,6 +393,7 @@ void addFilter(FilterType* filter, observation_t& observation)
     typename std::map<int, int>::iterator ai, aiEnd = m_assignments.end();
     for (ai = m_assignments.begin(); ai != aiEnd; ai++) {
       m_filters[ai->second].filter->observe(om, m_observations[ai->first].vec);
+      m_filters[ai->second].tag = m_observations[ai->first].tag;
     }
   }
 


### PR DESCRIPTION
This pull request enables tracking by `tag`, observations can now have a `tag` and if that `tag` is set to something else than `""` then only tracks that have the same `tag` will be associated. A tag of `""` is an anonymous filter, the moment it gets associated a non-anonymous observation it will become tight to that one.